### PR TITLE
Changing Command Filter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group 'spigot.gradle.project'
-version '3.3.2'
+version '3.3.3'
 
 repositories {
     mavenCentral()

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group 'spigot.gradle.project'
-version '3.3.3'
+version '3.3.4'
 
 repositories {
     mavenCentral()

--- a/src/main/java/com/nktfh100/AmongUs/events/PlayerCommand.java
+++ b/src/main/java/com/nktfh100/AmongUs/events/PlayerCommand.java
@@ -22,12 +22,7 @@ public class PlayerCommand implements Listener {
 		}
 		if (pInfo.getArena().getGameState() == GameState.RUNNING && !ev.getMessage().isEmpty()) {
 			String cmd = ev.getMessage().toLowerCase().split(" ")[0];
-			for (String cmd1 : Main.getConfigManager().getBlockedCommands()) {
-				if (cmd.equalsIgnoreCase(cmd1)) {
-					ev.setCancelled(true);
-					return;
-				}
-			}
+			if(!Main.getConfigManager().getAllowedCommands().contains(cmd.toLowerCase())) return;
 		}
 		if (ev.getMessage().equalsIgnoreCase("/aua test") && player.hasPermission("aua.test")) {
 			pInfo.getArena()._isTesting = true;

--- a/src/main/java/com/nktfh100/AmongUs/events/PlayerCommand.java
+++ b/src/main/java/com/nktfh100/AmongUs/events/PlayerCommand.java
@@ -20,11 +20,15 @@ public class PlayerCommand implements Listener {
 		if (!pInfo.getIsIngame()) {
 			return;
 		}
-		if (pInfo.getArena().getGameState() == GameState.RUNNING && !ev.getMessage().isEmpty()) {
+		if (!ev.getMessage().isEmpty()) {
 			String cmd = ev.getMessage().toLowerCase().split(" ")[0];
-			if(!Main.getConfigManager().getAllowedCommands().contains(cmd.toLowerCase())) return;
+			if(!Main.getConfigManager().getAllowedCommands().contains(cmd.toLowerCase())) {
+				ev.setCancelled(true);
+				player.sendMessage(ChatColor.DARK_RED + "You can't execute this command while ingame!");
+				return;
+			}
 		}
-		if (ev.getMessage().equalsIgnoreCase("/aua test") && player.hasPermission("aua.test")) {
+		if (pInfo.getArena().getGameState() == GameState.RUNNING && ev.getMessage().equalsIgnoreCase("/aua test") && player.hasPermission("aua.test")) {
 			pInfo.getArena()._isTesting = true;
 			pInfo.getArena().testingPlayer = player;
 			player.sendMessage(ChatColor.GREEN + "Enabled testing mode!");

--- a/src/main/java/com/nktfh100/AmongUs/events/PlayerRightClick.java
+++ b/src/main/java/com/nktfh100/AmongUs/events/PlayerRightClick.java
@@ -1,5 +1,6 @@
 package com.nktfh100.AmongUs.events;
 
+import com.nktfh100.AmongUs.inventory.ColorSelectorInv;
 import org.bukkit.block.Block;
 import org.bukkit.block.Sign;
 import org.bukkit.entity.Player;
@@ -66,7 +67,9 @@ public class PlayerRightClick implements Listener {
 					pInfo.getArena().playerLeave(player, false, false, true);
 				} else if (displayName.equals(itemsManager.getItem("colorSelector").getItem().getTitle())) {
 					ev.setCancelled(true);
-					player.openInventory(pInfo.getArena().getColorSelectorInv(player).getInventory());
+					ColorSelectorInv clrSelectorInv = pInfo.getArena().getColorSelectorInv(player);
+					clrSelectorInv.update();
+					player.openInventory(clrSelectorInv.getInventory());
 				} else if (displayName.equals(itemsManager.getItem("use").getItem2().getTitle())) {
 					ev.setCancelled(true);
 					switch (pInfo.getUseItemState()) {

--- a/src/main/java/com/nktfh100/AmongUs/info/Arena.java
+++ b/src/main/java/com/nktfh100/AmongUs/info/Arena.java
@@ -2292,8 +2292,8 @@ public class Arena {
 		placeholders.put("display_name", this.getDisplayName());
 		placeholders.put("state", this.gameState.name());
 		placeholders.put("lowercase_state", this.gameState.name().toLowerCase());
-		placeholders.put("players_min", String.valueOf(this.maxPlayers));
-		placeholders.put("players_max", String.valueOf(this.minPlayers));
+		placeholders.put("players_max", String.valueOf(this.maxPlayers));
+		placeholders.put("players_min", String.valueOf(this.minPlayers));
 		placeholders.put("players_count", String.valueOf(this.ingamePlayers.size()));
 		placeholders.put("imposter_count", String.valueOf(this.gameImposters.size()));
 

--- a/src/main/java/com/nktfh100/AmongUs/managers/ConfigManager.java
+++ b/src/main/java/com/nktfh100/AmongUs/managers/ConfigManager.java
@@ -41,7 +41,7 @@ public class ConfigManager {
 	private Boolean giveLobbyItems;
 	private HashMap<String, Integer> lobbyItemsSlots = null;
 	private Boolean showRunningArenas;
-	private List<String> blockedCommands = new ArrayList<String>();
+	private List<String> allowedCommands = new ArrayList<String>();
 	private HashMap<String, ColorInfo> colors = null;
 	private Boolean ghostsFly = true;
 	private Color asteroidsParticleColor = Color.RED;
@@ -82,7 +82,7 @@ public class ConfigManager {
 
 	public void loadConfigVars() {
 		this.lobbyItemsSlots = new HashMap<String, Integer>();
-		this.blockedCommands = new ArrayList<String>();
+		this.allowedCommands = new ArrayList<String>();
 		this.colors = new HashMap<String, ColorInfo>();
 
 		Main.getPlugin().reloadConfig();
@@ -111,7 +111,7 @@ public class ConfigManager {
 
 		this.enableGlassHelmet = this.config.getBoolean("enableGlassHelmet", true);
 
-		this.blockedCommands = this.config.getStringList("blockedCommands");
+		this.allowedCommands = this.config.getStringList("allowedCommands");
 
 		ConfigurationSection lobbyItemsSlotsSC = this.config.getConfigurationSection("lobbyItemsSlots");
 		for (String key : lobbyItemsSlotsSC.getKeys(false)) {
@@ -287,7 +287,7 @@ public class ConfigManager {
 		this.giveLobbyItems = null;
 		this.lobbyItemsSlots = null;
 		this.showRunningArenas = null;
-		this.blockedCommands = null;
+		this.allowedCommands = null;
 		this.colors = null;
 		this.ghostsFly = null;
 		this.asteroidsParticleColor = null;
@@ -347,8 +347,8 @@ public class ConfigManager {
 		return showRunningArenas;
 	}
 
-	public List<String> getBlockedCommands() {
-		return this.blockedCommands;
+	public List<String> getAllowedCommands() {
+		return this.allowedCommands;
 	}
 
 	public Boolean getGhostsFly() {

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -73,10 +73,7 @@ commands: # %player% - Player's name
    gameStartCrewmate: []
 
 allowedCommands:
-   - /msg
-   - /r
-   - /whisper
-   - /tell
+   - /aua
 
 asteroidsParticleColor: 255,0,0 # RGB
 asteroidsParticleMaterial: REDSTONE_BLOCK

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -72,7 +72,7 @@ commands: # %player% - Player's name
    gameStartImposter: []
    gameStartCrewmate: []
 
-blockedCommands:
+allowedCommands:
    - /msg
    - /r
    - /whisper

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,7 +1,7 @@
 name: AmongUs
 main: com.nktfh100.AmongUs.main.Main
 author: nktfh100
-version: 3.3.2
+version: 3.3.3
 api-version: 1.16
 depend: [ProtocolLib]
 softdepend: [PlayerPoints, Multiverse, Multiverse-Core, VentureChat, PlaceholderAPI, HolographicDisplays, DecentHolograms, TAB]

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,7 +1,7 @@
 name: AmongUs
 main: com.nktfh100.AmongUs.main.Main
 author: nktfh100
-version: 3.3.3
+version: 3.3.4
 api-version: 1.16
 depend: [ProtocolLib]
 softdepend: [PlayerPoints, Multiverse, Multiverse-Core, VentureChat, PlaceholderAPI, HolographicDisplays, DecentHolograms, TAB]


### PR DESCRIPTION
It is INCREDIBLY important that the command filter is a WHITELIST and not a BLACKLIST because if it is a BLACKLIST players can break the whole game if there is more than one minigame on the server by teleporting to another arena while ingame. Youre not able to figure out any single of those plugin command branches to put into the BLACKLIST!

This PR fixes this. (Already tested completely)